### PR TITLE
[211] bug didn`t confirmed but status was not documented. Operation s…

### DIFF
--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -56,6 +56,10 @@ public class EmailController {
      * @param message - object with all necessary data for sending email
      * @author Taras Kavkalo
      */
+    @Operation(summary = "Sending notification to User about status change")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
+    })
     @PostMapping("/changePlaceStatus")
     public ResponseEntity<Object> changePlaceStatus(@RequestBody SendChangePlaceStatusEmailMessage message) {
         emailService.sendChangePlaceStatusEmail(message.getAuthorFirstName(), message.getPlaceName(),


### PR DESCRIPTION
Environment: Firefox 116.0.3 (64-bit).
Reproducible: always.

Preconditions
Moved to Swagger http://localhost:8065/swagger-ui.html#/

Steps to reproduce

Click on Email controller
Click on POST/email/changePlaceStatus
Click on 'Try out'
Enter valid data {
"authorEmail": "[Admin1@gmail.com](mailto:Admin1@gmail.com)",
"authorFirstName": "Admin",
"placeName": "hoho",
"placeStatus": "string"
}
Actual result
Response 200 OK

Expected result
Response 401 Unauthorized

User story and test case links

**What was done:**
[211] bug didn`t confirmed but status was not documented. Operation summary added. 401 status documented  in EmailController.changePlaceStatus (/addEcoNews/changePlaceStatus)