### PR TITLE
[283] fixed response status code for /user/isOnline/{userId} endpoint from 401 to 403

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>
@@ -73,6 +78,11 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.api-client</groupId>

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -97,6 +97,7 @@ public class SecurityConfig {
                         .accessDeniedHandler((req, resp, exc) -> resp.sendError(
                                 SC_FORBIDDEN, "You don't have authorities.")))
                 .authorizeHttpRequests(req -> req
+                        .requestMatchers("/error").permitAll()
                         .requestMatchers("/static/css/**", "/static/img/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
@@ -133,7 +134,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, USER_LINK,
                                 "/user/shopping-list-items/habits/{habitId}/shopping-list",
                                 "/user/{userId}/{habitId}/custom-shopping-list-items/available",
-                                "/user/{userId}/profile/", "/user/isOnline/{userId}/",
+                                "/user/{userId}/profile/",
                                 "/user/{userId}/profileStatistics/",
                                 "/user/userAndSixFriendsWithOnlineStatus",
                                 "/user/userAndAllFriendsWithOnlineStatus",
@@ -152,6 +153,8 @@ public class SecurityConfig {
                                 "/ownSecurity/password-status",
                                 "/user/emailNotifications")
                         .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
+                        .requestMatchers(HttpMethod.GET, "/user/isOnline/{userId}/")
+                        .hasAnyRole(ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
                         .requestMatchers(HttpMethod.POST, USER_LINK,
                                 "/user/shopping-list-items",
                                 "/user/{userId}/habit",

--- a/core/src/test/java/greencity/controller/UserSecuredControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserSecuredControllerTest.java
@@ -1,0 +1,75 @@
+package greencity.controller;
+
+import greencity.config.SecurityConfig;
+import greencity.repository.UserRepo;
+import greencity.security.jwt.JwtTool;
+import greencity.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith({SpringExtension.class})
+@ContextConfiguration(classes = {SecurityConfig.class, JwtTool.class})
+@WebMvcTest
+class UserSecuredControllerTest {
+
+    static final String USER_LINK = "/user";
+    static final String ROLE_USER = "USER";
+    static final String ROLE_ADMIN = "ADMIN";
+
+    @MockBean
+    UserService userService;
+
+    @MockBean
+    UserRepo userRepo;
+
+    @Autowired
+    WebApplicationContext context;
+
+    MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup() {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(SecurityMockMvcConfigurers.springSecurity())
+                .build();
+    }
+
+    @Test
+    @DisplayName("Test response status for user is online endpoint as unauthenticated user")
+    void userIsOnline_EndpointResponse_StatusIsUnauthorized() throws Exception {
+        mockMvc.perform(get(USER_LINK + "/isOnline/{userId}/", 1L))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Test response status for user is online endpoint as authenticated USER")
+    @WithMockUser(roles = ROLE_USER)
+    void userIsOnline_EndpointResponse_StatusIsForbidden() throws Exception {
+        mockMvc.perform(get(USER_LINK + "/isOnline/{userId}/", 1L))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Test response status for user is online endpoint as authenticated ADMIN")
+    @WithMockUser(roles = ROLE_ADMIN)
+    void userIsOnline_EndpointResponse_StatusIsNotFound() throws Exception {
+        mockMvc.perform(get(USER_LINK + "/isOnline/{userId}/", 1L))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
# Pull request related to issue #283

## **Preconditions**  
Moved to Swagger [http://localhost:8060/swagger-ui.html#/](http://localhost:8060/swagger-ui.html#/)
Sign-in as User

## **Steps to reproduce**

1. Click on User controller
2. Click on GET /user/isOnline/{userId}/
3. Click on 'Try out'
4. Enter valid params

## **Changes**:
1. Updated SecurityConfig to deny access for **USER** role to */user/isOnline/{userId}/* endpoint
2. Updated SecurityConfig to permit access to */error endpoint
3. Added **spring-security-test** and **spring-boot-starter-test** dependencies to test **UserController** with enabled **SpringSecurity**
4. Added additional tests cases for **UserController** to test secured */user/isOnline/{userId}/* endpoint

> **NOTES:** additional @ApiResponse annotation for **checkIfTheUserIsOnline()** method related to issue [284]

## **Results:**
![image](https://github.com/GreenCityProject/GreenCityUser21_team_1_May/assets/128901331/fb48ffb2-7ef8-4496-868f-6a604f60aa68")
> *With authenticated USER role*

![image](https://github.com/GreenCityProject/GreenCityUser21_team_1_May/assets/128901331/561f9c70-0f40-42d7-ba24-bbd6c3195cf2)
> *Without authentication*

![image](https://github.com/GreenCityProject/GreenCityUser21_team_1_May/assets/128901331/12ba3178-d274-4000-8efc-df605bf54fdb)
> *With authenticated ADMIN role*