### PR TITLE
[352] fixed response status code for /user endpoint from 200 to 403

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>
@@ -73,6 +78,11 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.api-client</groupId>

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -97,6 +97,9 @@ public class SecurityConfig {
                         .accessDeniedHandler((req, resp, exc) -> resp.sendError(
                                 SC_FORBIDDEN, "You don't have authorities.")))
                 .authorizeHttpRequests(req -> req
+                        .requestMatchers("/error").permitAll()
+                        .requestMatchers(HttpMethod.GET, USER_LINK)
+                        .hasAnyRole(ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
                         .requestMatchers("/static/css/**", "/static/img/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(

--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -209,9 +209,8 @@ public class UserController {
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
     })
     @GetMapping
-    public ResponseEntity<UserUpdateDto> getUserByPrincipal(@ApiIgnore @AuthenticationPrincipal Principal principal) {
-        String email = principal.getName();
-        return ResponseEntity.status(HttpStatus.OK).body(userService.getUserUpdateDtoByEmail(email));
+    public ResponseEntity<UserUpdateDto> getUserByPrincipal(@ApiIgnore @AuthenticationPrincipal String principal) {
+        return ResponseEntity.status(HttpStatus.OK).body(userService.getUserUpdateDtoByEmail(principal));
     }
 
     /**

--- a/core/src/test/java/greencity/controller/UserSecuredControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserSecuredControllerTest.java
@@ -1,0 +1,75 @@
+package greencity.controller;
+
+import greencity.config.SecurityConfig;
+import greencity.repository.UserRepo;
+import greencity.security.jwt.JwtTool;
+import greencity.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith({SpringExtension.class})
+@ContextConfiguration(classes = {SecurityConfig.class, JwtTool.class})
+@WebMvcTest
+class UserSecuredControllerTest {
+
+    static final String USER_LINK = "/user";
+    static final String ROLE_USER = "USER";
+    static final String ROLE_ADMIN = "ADMIN";
+
+    @MockBean
+    UserService userService;
+
+    @MockBean
+    UserRepo userRepo;
+
+    @Autowired
+    WebApplicationContext context;
+
+    MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup() {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(SecurityMockMvcConfigurers.springSecurity())
+                .build();
+    }
+
+    @Test
+    @DisplayName("Test response status for user get endpoint as unauthenticated user")
+    void getUser_EndpointResponse_StatusIsUnauthorized() throws Exception {
+        mockMvc.perform(get(USER_LINK))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Test response status for user get endpoint as authenticated USER")
+    @WithMockUser(roles = ROLE_USER)
+    void getUser_EndpointResponse_StatusIsForbidden() throws Exception {
+        mockMvc.perform(get(USER_LINK))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Test response status for user get endpoint as authenticated ADMIN")
+    @WithMockUser(roles = ROLE_ADMIN)
+    void userIsOnline_EndpointResponse_StatusIsNotFound() throws Exception {
+        mockMvc.perform(get(USER_LINK))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
# Pull request related to issue #352

## Preconditions 
Moved to Swagger [http://localhost:8060/swagger-ui.html#/](http://localhost:8060/swagger-ui.html#/)
Sign-in as User

## Steps to reproduce

1. Click on User controller.
2. Click on GET /user.
3. Click on 'Try out'.

## Changes:
1. Updated SecurityConfig to permit access to */error* endpoint and to restrict access for **USER** role to */user* endpoint.
2. Fixed **UserController** **getUserByPrincipal()** method to resolve **NullPointerException** (500 Internal Server Error raises)
3. Added **spring-security-test** and **spring-boot-starter-test** dependencies to test **UserController** with enabled **SpringSecurity**
4. Added additional tests cases for **UserController** to test secured */user* endpoint

> **NOTES:** Annotation @AuthenticationPrincipal returns username (String) as email of authenticated user.

## Results:
![image](https://github.com/GreenCityProject/GreenCityUser21_team_1_May/assets/128901331/e77b873f-0fe3-4505-93d4-0de4b177fb20)
> *Without authentication*

![image](https://github.com/GreenCityProject/GreenCityUser21_team_1_May/assets/128901331/879d552e-bf5b-4687-a55b-3d688a04c1b0)
> *With authenticated USER role*

![image](https://github.com/GreenCityProject/GreenCityUser21_team_1_May/assets/128901331/9104b657-60e1-4cf0-ba6b-27050f0ee389)
> *With authenticated ADMIN role*