### PR TITLE
[246] fixed sendUserViolation() with wrong email Response 404 Not found

### DIFF
--- a/service/src/main/java/greencity/service/EmailServiceImpl.java
+++ b/service/src/main/java/greencity/service/EmailServiceImpl.java
@@ -1,6 +1,5 @@
 package greencity.service;
 
-import greencity.constant.AppConstant;
 import greencity.constant.EmailConstants;
 import greencity.constant.ErrorMessage;
 import greencity.constant.LogMessage;
@@ -14,7 +13,6 @@ import greencity.dto.user.PlaceAuthorDto;
 import greencity.dto.user.UserActivationDto;
 import greencity.dto.user.UserDeactivationReasonDto;
 import greencity.dto.violation.UserViolationMailDto;
-import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.repository.UserRepo;
 import jakarta.mail.MessagingException;
@@ -276,10 +274,10 @@ public class EmailServiceImpl implements EmailService {
         model.put(EmailConstants.LANGUAGE, dto.getLanguage());
         changeLocale(dto.getLanguage());
         String template = createEmailTemplate(model, EmailConstants.USER_VIOLATION_PAGE);
-        if (!userRepo.existsUserByEmail(dto.getEmail())) {
-            throw new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + dto.getEmail());
-        } else {
+        if (userRepo.existsUserByEmail(dto.getEmail())) {
             sendEmail(dto.getEmail(), EmailConstants.VIOLATION_EMAIL, template);
+        } else {
+            throw new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + dto.getEmail());
         }
     }
 

--- a/service/src/main/java/greencity/service/EmailServiceImpl.java
+++ b/service/src/main/java/greencity/service/EmailServiceImpl.java
@@ -1,5 +1,6 @@
 package greencity.service;
 
+import greencity.constant.AppConstant;
 import greencity.constant.EmailConstants;
 import greencity.constant.ErrorMessage;
 import greencity.constant.LogMessage;
@@ -13,6 +14,7 @@ import greencity.dto.user.PlaceAuthorDto;
 import greencity.dto.user.UserActivationDto;
 import greencity.dto.user.UserDeactivationReasonDto;
 import greencity.dto.violation.UserViolationMailDto;
+import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.repository.UserRepo;
 import jakarta.mail.MessagingException;
@@ -274,7 +276,11 @@ public class EmailServiceImpl implements EmailService {
         model.put(EmailConstants.LANGUAGE, dto.getLanguage());
         changeLocale(dto.getLanguage());
         String template = createEmailTemplate(model, EmailConstants.USER_VIOLATION_PAGE);
-        sendEmail(dto.getEmail(), EmailConstants.VIOLATION_EMAIL, template);
+        if (!userRepo.existsUserByEmail(dto.getEmail())) {
+            throw new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + dto.getEmail());
+        } else {
+            sendEmail(dto.getEmail(), EmailConstants.VIOLATION_EMAIL, template);
+        }
     }
 
     @Override

--- a/service/src/test/java/greencity/service/EmailServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EmailServiceImplTest.java
@@ -16,6 +16,7 @@ import greencity.entity.User;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.repository.UserRepo;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -170,6 +171,7 @@ class EmailServiceImplTest {
     }
 
     @Test
+    @DisplayName("Test for sending user violation email when user doesn't exist")
     void sendUserViolationEmail_userNotFound_throwsNotFoundException() {
         UserViolationMailDto dto = ModelUtils.getUserViolationMailDto();
         when(userRepo.existsUserByEmail(dto.getEmail())).thenReturn(false);
@@ -180,17 +182,15 @@ class EmailServiceImplTest {
     }
 
     @Test
-    void sendUserViolationEmail_userExists_sendsEmail(){
+    @DisplayName("Test for sending user violation email when user exists")
+    void sendUserViolationEmail_userExists_sendsEmail() {
         UserViolationMailDto dto = ModelUtils.getUserViolationMailDto();
         when(userRepo.existsUserByEmail(dto.getEmail())).thenReturn(true);
 
-        MimeMessage mimeMessage = mock(MimeMessage.class);
-        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
-
         service.sendUserViolationEmail(dto);
 
+        verify(userRepo).existsUserByEmail(dto.getEmail());
         verify(javaMailSender).createMimeMessage();
-        verify(javaMailSender).send(mimeMessage);
     }
 
     @Test

--- a/service/src/test/java/greencity/service/EmailServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EmailServiceImplTest.java
@@ -30,8 +30,7 @@ import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 class EmailServiceImplTest {
@@ -171,10 +170,27 @@ class EmailServiceImplTest {
     }
 
     @Test
-    void sendUserViolationEmailTest() {
+    void sendUserViolationEmail_userNotFound_throwsNotFoundException() {
         UserViolationMailDto dto = ModelUtils.getUserViolationMailDto();
+        when(userRepo.existsUserByEmail(dto.getEmail())).thenReturn(false);
+
+        assertThrows(NotFoundException.class, () -> service.sendUserViolationEmail(dto));
+
+        verify(javaMailSender, never()).createMimeMessage();
+    }
+
+    @Test
+    void sendUserViolationEmail_userExists_sendsEmail(){
+        UserViolationMailDto dto = ModelUtils.getUserViolationMailDto();
+        when(userRepo.existsUserByEmail(dto.getEmail())).thenReturn(true);
+
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
         service.sendUserViolationEmail(dto);
+
         verify(javaMailSender).createMimeMessage();
+        verify(javaMailSender).send(mimeMessage);
     }
 
     @Test


### PR DESCRIPTION
For valid data, except for the email 
```
{
"email": "Test1gmail.com",
"language": "en",
"name": "Test1",
"violationDescription": "124125sfgg"
}
```

![image](https://github.com/GreenCityProject/GreenCityUser21_team_1_May/assets/123461356/cb55c385-c37f-483e-a788-00fe42813327)
