### PR TITLE
[210] fixed response status code for /email/changePlaceStatus endpoint from 200 to 404

### DIFF
--- a/core/src/main/java/greencity/controller/EmailController.java
+++ b/core/src/main/java/greencity/controller/EmailController.java
@@ -46,7 +46,7 @@ public class EmailController {
     @PostMapping("/sendReport")
     public ResponseEntity<Object> sendReport(@RequestBody SendReportEmailMessage message) {
         emailService.sendAddedNewPlacesReportEmail(message.getSubscribers(), message.getCategoriesDtoWithPlacesDtoMap(),
-            message.getEmailNotification());
+                message.getEmailNotification());
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
@@ -56,10 +56,17 @@ public class EmailController {
      * @param message - object with all necessary data for sending email
      * @author Taras Kavkalo
      */
+    @Operation(summary = "Send email notification about place status change")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
     @PostMapping("/changePlaceStatus")
     public ResponseEntity<Object> changePlaceStatus(@RequestBody SendChangePlaceStatusEmailMessage message) {
         emailService.sendChangePlaceStatusEmail(message.getAuthorFirstName(), message.getPlaceName(),
-            message.getPlaceStatus(), message.getAuthorEmail());
+                message.getPlaceStatus(), message.getAuthorEmail());
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
@@ -99,14 +106,14 @@ public class EmailController {
      */
     @Operation(summary = "Send notification to user via email")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
     })
     @PostMapping("/notification")
     public ResponseEntity<Object> sendUserNotification(@RequestBody NotificationDto notification,
-        @RequestParam("email") String email) {
+                                                       @RequestParam("email") String email) {
         emailService.sendNotificationByEmail(notification, email);
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/service/src/main/java/greencity/service/EmailServiceImpl.java
+++ b/service/src/main/java/greencity/service/EmailServiceImpl.java
@@ -84,7 +84,11 @@ public class EmailServiceImpl implements EmailService {
         model.put(EmailConstants.STATUS, placeStatus);
 
         String template = createEmailTemplate(model, EmailConstants.CHANGE_PLACE_STATUS_EMAIL_PAGE);
-        sendEmail(authorEmail, EmailConstants.GC_CONTRIBUTORS, template);
+        if (userRepo.existsUserByEmail(authorEmail)) {
+            sendEmail(authorEmail, EmailConstants.GC_CONTRIBUTORS, template);
+        } else {
+            throw new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_EMAIL + authorEmail);
+        }
     }
 
     @Override

--- a/service/src/test/java/greencity/service/EmailServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EmailServiceImplTest.java
@@ -1,6 +1,7 @@
 package greencity.service;
 
 import greencity.ModelUtils;
+import greencity.TestConst;
 import greencity.dto.category.CategoryDto;
 import greencity.dto.econews.AddEcoNewsDtoResponse;
 import greencity.dto.econews.EcoNewsForSendEmailDto;
@@ -15,6 +16,7 @@ import greencity.entity.User;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.repository.UserRepo;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -59,12 +61,27 @@ class EmailServiceImplTest {
 
     @Test
     void sendChangePlaceStatusEmailTest() {
+        when(userRepo.existsUserByEmail(TestConst.EMAIL)).thenReturn(true);
+
         String authorFirstName = "test author first name";
         String placeName = "test place name";
         String placeStatus = "test place status";
-        String authorEmail = "test author email";
+        String authorEmail = TestConst.EMAIL;
         service.sendChangePlaceStatusEmail(authorFirstName, placeName, placeStatus, authorEmail);
         verify(javaMailSender).createMimeMessage();
+    }
+
+    @Test
+    @DisplayName("Test for checking the response status of the endpoint /email/changePlaceStatus with invalid data")
+    void emailChangePlaceStatusEmail_EndpointResponse_StatusIsNotFound() throws Exception {
+        when(userRepo.existsUserByEmail(TestConst.EMAIL)).thenReturn(false);
+
+        String authorFirstName = "test author first name";
+        String placeName = "test place name";
+        String placeStatus = "test place status";
+        String authorEmail = TestConst.EMAIL;
+
+        assertThrows(NotFoundException.class, () -> service.sendChangePlaceStatusEmail(authorFirstName, placeName, placeStatus, authorEmail));
     }
 
     @Test


### PR DESCRIPTION
# Pull request related to issue #210

## Preconditions 
Moved to Swagger [http://localhost:8060/swagger-ui.html#/](http://localhost:8060/swagger-ui.html#/)
Sign-in as Admin

## Steps to reproduce

1. Click on Email controller.
2. Click on POST /email/changePlaceStatus.
3. Click on 'Try out'.
4. Enter data {  
    "authorEmail": "[Admin1@gmail.com](mailto:Admin1@gmail.com)",  
    "authorFirstName": "Test",  
    "placeName": "hoho",  
    "placeStatus": "string"  
    }

## Changes:
1. Added to **EmailController** undocumented Swagger response status codes for */email/changePlaceStatus* endpoint.
2. Added precondition to **EmailServiceImpl** **sendEmail()** method to verify that email author exists and can send message.
3. Added additional tests cases for **EmailServiceImpl** to test */email/changePlaceStatus* endpoint
## Results:
![image](https://github.com/GreenCityProject/GreenCityUser21_team_1_May/assets/128901331/09fb6930-9de0-470a-bc21-28fa56af0773)
> *authorEmail doesn't exists*

![image](https://github.com/GreenCityProject/GreenCityUser21_team_1_May/assets/128901331/c539a3ed-d172-4bec-a220-4fe433ce05e5)
> *authorEmail exists*